### PR TITLE
revert py3exiv2bind to version 0.1.11

### DIFF
--- a/requirements/requirements-dev-freeze.txt
+++ b/requirements/requirements-dev-freeze.txt
@@ -18,7 +18,7 @@ docopt==0.6.2
 docutils==0.20.1
 exceptiongroup==1.2.0
 filelock==3.13.1
-flake8==6.1.0
+flake8==7.0.0
 flake8-bugbear==23.12.2
 HathiValidate==0.3.8
 HathiZip==0.1.11
@@ -46,11 +46,11 @@ paramiko==3.4.0
 pkginfo==1.9.6
 platformdirs==4.1.0
 pluggy==1.3.0
-py3exiv2bind==0.1.13.post1
+py3exiv2bind==0.1.11
 pycodestyle==2.11.1
 pycparser==2.21
 pydocstyle==6.3.0
-pyflakes==3.1.0
+pyflakes==3.2.0
 Pygments==2.17.2
 pyhathiprep==0.1.10
 pykdu_compress==0.1.9

--- a/requirements/requirements-gui-freeze.txt
+++ b/requirements/requirements-gui-freeze.txt
@@ -10,7 +10,7 @@ importlib-resources==6.1.1
 lxml==5.0.0
 multidict==6.0.4
 pluggy==1.3.0
-py3exiv2bind==0.1.13.post1
+py3exiv2bind==0.1.11
 pyhathiprep==0.1.10
 pykdu_compress==0.1.9
 pyqt-distutils==0.7.3

--- a/requirements/requirements-vendor-source.txt
+++ b/requirements/requirements-vendor-source.txt
@@ -4,6 +4,6 @@ git+https://github.com/UIUCLibrary/pyhathiprep.git@0.1.10
 # git+https://github.com/UIUCLibrary/pykdu_compress.git@0.1.9
 git+https://github.com/UIUCLibrary/Packager.git@0.2.15
 git+https://github.com/UIUCLibrary/uiucprescon.images.git@v0.0.5
-git+https://github.com/UIUCLibrary/pyexiv2bind.git@0.1.13.post1
+git+https://github.com/UIUCLibrary/pyexiv2bind.git@0.1.11
 git+https://github.com/UIUCLibrary/imagevalidate.git@0.1.9.post3
 git+https://github.com/UIUCLibrary/Tesseract_Glue.git@0.1.4.post2

--- a/requirements/requirements-vendor.txt
+++ b/requirements/requirements-vendor.txt
@@ -3,7 +3,7 @@
 
 HathiValidate==0.3.8
 HathiZip==0.1.11
-py3exiv2bind==0.1.13.post1
+py3exiv2bind==0.1.11
 pyhathiprep==0.1.10
 pykdu-compress==0.1.9
 uiucprescon.images==0.0.5


### PR DESCRIPTION
This is due to a bug in exiv2 which causes writing xmp metadata to jp2 files will erase all xmp metadata stored in the file.